### PR TITLE
embention/Embention#7040 - added changes to latex conf

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -212,6 +212,7 @@ htmlhelp_basename = 'NmandManualsDoc'
 # -- Options for LaTeX output ---------------------------------------------
 
 latex_elements = {
+  'figure_align': 'H'
 # The paper size ('letterpaper' or 'a4paper').
 #'papersize': 'letterpaper',
 


### PR DESCRIPTION
# Related code issue:
https://github.com/embention/Embention/issues/7040
# Description:
Para que las imágenes salgan donde corresponde al generarse el pdf se tiene que agregar el siguiente comando al conf.py, en el apartado de latex_elements: 'figure_align':'H'