### PR TITLE
Feature/rtd/127 rtd version & date fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ task rtd_html(type:Exec){
       println version_rtd
       version_=project.version_rtd
   }
-  commandLine "sphinx-build",'-T','-b','html', '-q', '-d', '_build/doctrees-readthedocs','-D', 'version='+version_,'.','_build/html'
+  commandLine "sphinx-build",'-T','-b','html', '-q', '-d', '_build/doctrees-readthedocs','-D', 'version=' + version_, '.', '_build/html'
 }
 
 task rtd_latex(type:Exec){
@@ -76,7 +76,13 @@ task rtd_epub(type:Exec){
       println version_rtd
       version_=project.version_rtd
   }
-  commandLine "sphinx-build",'-b','epub', '-q', '-d', '_build/doctrees-readthedocs', '-D', 'version='+version_,'.','_build/epub'
+
+  if (project.hasProperty('today_rtd') && project.today_rtd != 'unspecified') {
+    println project.today_rtd
+    commandLine "sphinx-build",'-b','epub', '-q', '-d', '_build/doctrees-readthedocs', '-D', 'version=' + version_, '-D', 'release=' + version_, '-D', 'today=' + project.today_rtd, '.', '_build/epub'
+  } else {
+    commandLine "sphinx-build",'-b','epub', '-q', '-d', '_build/doctrees-readthedocs', '-D', 'version=' + version_, '-D', 'release=' + version_, '.','_build/epub'
+  }
 }
 
 task clean_pdf_build(type:Delete) {

--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,13 @@ task rtd_latex(type:Exec){
       println version_rtd
       version_=project.version_rtd
   }
-  commandLine "sphinx-build",'-b','latex', '-q', '-d', '_build/doctrees-readthedocs', '-D','language='+project.name , '-D', 'version='+version_,'.','_build/latex'
+
+  if (project.hasProperty('today_rtd') && project.today_rtd != 'unspecified') {
+    println project.today_rtd
+    commandLine "sphinx-build",'-b','latex', '-q', '-d', '_build/doctrees-readthedocs', '-D','language=' + project.name , '-D', 'version=' + version_, '-D', 'release=' + version_, '-D', 'today=' + project.today_rtd, '.', '_build/latex'
+  } else {
+    commandLine "sphinx-build",'-b','latex', '-q', '-d', '_build/doctrees-readthedocs', '-D','language=' + project.name , '-D', 'version=' + version_, '-D', 'release=' + version_, '.', '_build/latex'
+  }
 }
 
 


### PR DESCRIPTION
# References
https://github.com/embention/RTD/issues/127

# Changelog
* Added: New parameter to add date in PDF documents
* Added: New parameter to add date in EPUB documents
* Fixed: Parameter to show the version in the PDF documents
* Fixed: Prameter to show the version in the EPUB documents

# Description
Este PR se deberá probar en conjunto con los siguientes:
- https://github.com/embention/ci-jobs/pull/538
- https://github.com/embention/RTD/pull/136
- https://github.com/embention/Python_libs/pull/304

Se deberá comprobar que el PDF y EPUB generados tengan la fecha del commit establecido y la versión establecida.

**IMPORTANTE**: Para probar un ciclo completo de los cambios de este conjunto de pulls será necesario tener lo siguiente preparado:
- Jenkins local funcionando y con los jobs modificados para apuntar a la rama presentada en el pull https://github.com/embention/ci-jobs/pull/538 además del puntero de Python_libs actualizado a la rama presentada en el pull https://github.com/embention/Python_libs/pull/304. Se ha generado una [rama review](https://github.com/embention/ci-jobs/tree/feature/RTD/127_RTD_Version_%26_Date_Fix_REVIEW) con modificaciones de desarrollo para realizar estas pruebas de forma más sencilla. Se deberán cambiar aún así los datos de conectividad para que coincidan con los del revisor.
- Instancia local de Odoo para no modificar producción
- Instancia local de RTD Server Flask con los cambios presentados en el pull https://github.com/embention/RTD/pull/136 para comprobar la subida de los archivos y la correcta generación del PDF